### PR TITLE
Change elmPorts to ports because js library expects ports instead of elmPorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ import * as Web from "@lue-bird/elm-state-interface";
 
 const elmApp = Main.init();
 Web.programStart({
-    elmPorts : elmApp.ports,
+    ports : elmApp.ports,
     domElement : document.getElementById("your-app-element-id")
 });
 ```


### PR DESCRIPTION
I struggled to run this library and found out that example is incorrect